### PR TITLE
Data provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```sh
 $ make testacc
 ```
+
+The `MAILGUN_API_KEY` environment variable must be set to run the acceptance tests.

--- a/mailgun/data_source_mailgun_domain.go
+++ b/mailgun/data_source_mailgun_domain.go
@@ -1,0 +1,34 @@
+package mailgun
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/pearkes/mailgun"
+)
+
+func dataSourceMailgunDomain() *schema.Resource {
+
+	mailgunSchema := resourceMailgunSchema()
+	mailgunSchema["smtp_password"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+
+	return &schema.Resource{
+		Read:   dataSourceMailgunDomainRead,
+		Schema: mailgunSchema,
+	}
+}
+
+func dataSourceMailgunDomainRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*mailgun.Client)
+	name := d.Get("name").(string)
+
+	_, err := resourceMailginDomainRetrieve(name, client, d)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(name)
+	return nil
+}

--- a/mailgun/data_source_mailgun_domain_test.go
+++ b/mailgun/data_source_mailgun_domain_test.go
@@ -1,0 +1,74 @@
+package mailgun
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccMailgunDomainDataSource_Basic(t *testing.T) {
+	uuid, _ := uuid.GenerateUUID()
+	domain := fmt.Sprintf("terraform.%s.com", uuid)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMailgunDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMailgunDomainDataSourceConfig_Basic(domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceMailgunDomainCheck("data.mailgun_domain.test", domain),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMailgunDomainCheck(name string, domain string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s\n%#v", name, rs)
+		}
+
+		attr := rs.Primary.Attributes
+
+		if attr["name"] != domain {
+			return fmt.Errorf("bad name %s", attr["name"])
+		}
+
+		if attr["spam_action"] != "disabled" {
+			return fmt.Errorf("Bad spam_action: %s", attr["spam_action"])
+		}
+
+		if attr["wildcard"] != "false" {
+			return fmt.Errorf("Bad wildcard: %s", attr["wildcard"])
+		}
+
+		if attr["smtp_password"] == "" {
+			return fmt.Errorf("Bad smtp_password: %s", attr["smtp_password"])
+		}
+
+		return nil
+	}
+}
+
+func testAccMailgunDomainDataSourceConfig_Basic(domain string) string {
+	return fmt.Sprintf(`
+resource "mailgun_domain" "foobar" {
+	name = "%s"
+	spam_action = "disabled"
+	smtp_password = "foobar"
+	wildcard = false
+}
+
+data "mailgun_domain" "test" {
+	name = "${mailgun_domain.foobar.name}"
+}
+`, domain)
+}

--- a/mailgun/provider.go
+++ b/mailgun/provider.go
@@ -18,6 +18,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"mailgun_domain": dataSourceMailgunDomain(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"mailgun_domain": resourceMailgunDomain(),
 		},

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -4,13 +4,98 @@ import (
 	"fmt"
 	"log"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pearkes/mailgun"
 )
+
+func resourceMailgunSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"spam_action": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+			ForceNew: true,
+			Optional: true,
+		},
+
+		"smtp_password": &schema.Schema{
+			Type:     schema.TypeString,
+			ForceNew: true,
+			Required: true,
+		},
+
+		"smtp_login": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+
+		"wildcard": &schema.Schema{
+			Type:     schema.TypeBool,
+			Computed: true,
+			ForceNew: true,
+			Optional: true,
+		},
+
+		"receiving_records": &schema.Schema{
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"priority": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"record_type": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"valid": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"value": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"sending_records": &schema.Schema{
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"record_type": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"valid": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"value": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}
 
 func resourceMailgunDomain() *schema.Resource {
 	return &schema.Resource{
@@ -23,89 +108,7 @@ func resourceMailgunDomain() *schema.Resource {
 
 		SchemaVersion: 2,
 
-		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"spam_action": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-				ForceNew: true,
-				Optional: true,
-			},
-
-			"smtp_password": &schema.Schema{
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
-
-			"smtp_login": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-			},
-
-			"wildcard": &schema.Schema{
-				Type:     schema.TypeBool,
-				Computed: true,
-				ForceNew: true,
-				Optional: true,
-			},
-
-			"receiving_records": &schema.Schema{
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"priority": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"record_type": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"valid": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"value": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
-			"sending_records": &schema.Schema{
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"record_type": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"valid": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"value": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-		},
+		Schema: resourceMailgunSchema(),
 	}
 }
 

--- a/mailgun/resource_mailgun_domain_test.go
+++ b/mailgun/resource_mailgun_domain_test.go
@@ -2,8 +2,10 @@ package mailgun
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/pearkes/mailgun"
@@ -11,19 +13,19 @@ import (
 
 func TestAccMailgunDomain_Basic(t *testing.T) {
 	var resp mailgun.DomainResponse
-
+	uuid, _ := uuid.GenerateUUID()
+	domain := fmt.Sprintf("terraform.%s.com", uuid)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMailgunDomainDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckMailgunDomainConfig_basic,
+				Config: testAccCheckMailgunDomainConfig_basic(domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMailgunDomainExists("mailgun_domain.foobar", &resp),
-					testAccCheckMailgunDomainAttributes(&resp),
 					resource.TestCheckResourceAttr(
-						"mailgun_domain.foobar", "name", "terraform.example.com"),
+						"mailgun_domain.foobar", "name", domain),
 					resource.TestCheckResourceAttr(
 						"mailgun_domain.foobar", "spam_action", "disabled"),
 					resource.TestCheckResourceAttr(
@@ -33,7 +35,23 @@ func TestAccMailgunDomain_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mailgun_domain.foobar", "receiving_records.0.priority", "10"),
 					resource.TestCheckResourceAttr(
-						"mailgun_domain.foobar", "sending_records.0.name", "terraform.example.com"),
+						"mailgun_domain.foobar", "receiving_records.0.value", "mxa.mailgun.org"),
+					resource.TestCheckResourceAttr(
+						"mailgun_domain.foobar", "receiving_records.1.priority", "10"),
+					resource.TestCheckResourceAttr(
+						"mailgun_domain.foobar", "receiving_records.1.value", "mxb.mailgun.org"),
+					resource.TestCheckResourceAttr(
+						"mailgun_domain.foobar", "sending_records.1.name", fmt.Sprintf("email.%s", domain)),
+					resource.TestCheckResourceAttr(
+						"mailgun_domain.foobar", "sending_records.1.value", "mailgun.org"),
+					resource.TestCheckResourceAttr(
+						"mailgun_domain.foobar", "sending_records.2.name", domain),
+					resource.TestCheckResourceAttr(
+						"mailgun_domain.foobar", "sending_records.2.value", "v=spf1 include:mailgun.org ~all"),
+					resource.TestMatchResourceAttr(
+						"mailgun_domain.foobar", "sending_records.0.name", regexp.MustCompile(fmt.Sprintf("_domainkey.%s$", domain))),
+					resource.TestMatchResourceAttr(
+						"mailgun_domain.foobar", "sending_records.0.value", regexp.MustCompile("^k=rsa; p=")),
 				),
 			},
 		},
@@ -56,37 +74,6 @@ func testAccCheckMailgunDomainDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckMailgunDomainAttributes(DomainResp *mailgun.DomainResponse) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-
-		if DomainResp.Domain.Name != "terraform.example.com" {
-			return fmt.Errorf("Bad name: %s", DomainResp.Domain.Name)
-		}
-
-		if DomainResp.Domain.SpamAction != "disabled" {
-			return fmt.Errorf("Bad spam_action: %s", DomainResp.Domain.SpamAction)
-		}
-
-		if DomainResp.Domain.Wildcard != true {
-			return fmt.Errorf("Bad wildcard: %t", DomainResp.Domain.Wildcard)
-		}
-
-		if DomainResp.Domain.SmtpPassword != "foobar" {
-			return fmt.Errorf("Bad smtp_password: %s", DomainResp.Domain.SmtpPassword)
-		}
-
-		if DomainResp.ReceivingRecords[0].Priority == "" {
-			return fmt.Errorf("Bad receiving_records: %s", DomainResp.ReceivingRecords)
-		}
-
-		if DomainResp.SendingRecords[0].Name == "" {
-			return fmt.Errorf("Bad sending_records: %s", DomainResp.SendingRecords)
-		}
-
-		return nil
-	}
 }
 
 func testAccCheckMailgunDomainExists(n string, DomainResp *mailgun.DomainResponse) resource.TestCheckFunc {
@@ -119,10 +106,12 @@ func testAccCheckMailgunDomainExists(n string, DomainResp *mailgun.DomainRespons
 	}
 }
 
-const testAccCheckMailgunDomainConfig_basic = `
+func testAccCheckMailgunDomainConfig_basic(domain string) string {
+	return fmt.Sprintf(`
 resource "mailgun_domain" "foobar" {
-    name = "terraform.example.com"
+    name = "%s"
     spam_action = "disabled"
     smtp_password = "foobar"
     wildcard = true
-}`
+}`, domain)
+}

--- a/website/docs/d/domain.html.markdown
+++ b/website/docs/d/domain.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "mailgun"
+page_title: "Mailgun: mailgun_domain"
+sidebar_current: "docs-mailgun-datasource-mailgun-domain"
+description: |-
+  Provides details about a Mailgun domain.
+---
+
+# mailgun\_domain
+
+`mailgun_domain` provides details about a Mailgun domain.
+
+## Example Usage
+
+```hcl
+data "mailgun_domain" "domain" {
+  name = "test.example.com"
+}
+
+resource "aws_route53_record" "mailgun-mx" {
+  zone_id = "${var.zone_id}"
+  name    = "${data.mailgun.domain.name}"
+  type    = "MX"
+  ttl     = 3600
+  records = [
+    "${data.mailgun_domain.domain.receiving_records.0.priority} ${data.mailgun_domain.domain.receiving_records.0.value}.",
+    "${data.mailgun_domain.domain.receiving_records.1.priority} ${data.mailgun_domain.domain.receiving_records.1.value}.",
+  ]
+}
+```
+
+## Argument Reference
+
+* `name` - The name of the domain.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the domain.
+* `smtp_login` - The login email for the SMTP server.
+* `smtp_password` - The password to the SMTP server.
+* `wildcard` - Whether or not the domain will accept email for sub-domains.
+* `spam_action` - The spam filtering setting.
+* `receiving_records` - A list of DNS records for receiving validation.
+    * `priority` - The priority of the record.
+    * `record_type` - The record type.
+    * `valid` - `"valid"` if the record is valid.
+    * `value` - The value of the record.
+* `sending_records` - A list of DNS records for sending validation.
+    * `name` - The name of the record.
+    * `record_type` - The record type.
+    * `valid` - `"valid"` if the record is valid.
+    * `value` - The value of the record.


### PR DESCRIPTION
This also sorts the sending and receiving records by their value. The Mailgun API returns the records in indeterminate order causing Terraform to detect a change when there are none. I can separate the changes to multiple PRs if you prefer. 
  